### PR TITLE
新增isAutoRemove配置

### DIFF
--- a/src/dialog-config.js
+++ b/src/dialog-config.js
@@ -63,6 +63,9 @@ define({
     // 注意：css 只允许加载一个
     cssUri: '../css/ui-dialog.css',
 
+    // 是否在tirgger一些未定义的事件的时候，自动在close之后remove掉弹窗
+    isAutoRemove: true,
+
     // 模板（使用 table 解决 IE7 宽度自适应的 BUG）
     // js 使用 i="***" 属性识别结构，其余的均可自定义
     innerHTML:

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -454,8 +454,19 @@ $.extend(prototype, {
     _trigger: function (id) {
         var fn = this.callbacks[id];
             
-        return typeof fn !== 'function' || fn.call(this) !== false ?
-            this.close().remove() : this;
+        if (typeof fn !== 'function' || fn.call(this) !== false) {
+
+            // 根据是否isAutoRemove来判断是否需要执行remove()
+            if (this.isAutoRemove) {
+                res = this.close().remove();
+            } else {
+                res = this.close();
+            }
+        } else {
+            res = this;
+        }
+
+        return res;
     }
     
 });

--- a/test/isAutoRemove.html
+++ b/test/isAutoRemove.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="zh">
+<head>
+	<meta charset="UTF-8">
+	<title>test</title>
+</head>
+<body>
+<button data-event="test">open dialog</button>
+<script src="../lib/sea.js"></script>
+<script>
+seajs.config({
+  alias: {
+    "jquery": "jquery-1.10.2.js"
+  }
+});
+</script>
+
+<script>
+seajs.use(['jquery', '../src/dialog'], function ($, dialog) {
+
+
+	$('button[data-event=test]').on('click', function () {
+		var d = dialog({
+			title: '消息',
+			content: '风吹起的青色衣衫，夕阳里的温暖容颜，你比以前更加美丽，像盛开的花<br>——许巍《难忘的一天》',
+			quickClose: true,
+
+            /**
+             * 设定为false, 在没有设定cancel的时候 点击空白处关闭 不删除dialog的结构 
+             * 设定为true, 在没有设定cancel的时候 点击空白处关闭 删除dialog结构
+             */
+            isAutoRemove: true 
+		});
+
+		d.show();
+	});
+
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
现在artDialog在trigger了一些没有对应的回调的事件时, 是默认close().remove() 进行处理的.

但是有些时候, 比如快速关闭的时候, 不想很麻烦的去配置cancel回调, 而且如果不查看源码也不知道quickClose关闭弹窗是触发的cancel事件.

这个时候, 如果有一个isAutoRemove的配置, 在使用上就比较方便一点. 

设定了isAutoRemove为true 那么默认关闭的时候(quickClose, 关闭按钮点击等)就关闭和移除dom

设定了isAutoRemove为false 那么上述情况下 就只是关闭 不移除dom