### PR TITLE
解决弹窗按钮问题

### DIFF
--- a/src/dialog.js
+++ b/src/dialog.js
@@ -390,7 +390,7 @@ $.extend(prototype, {
                     '</button>';
 
                 that._$('button')
-                    .on('click', '[i-id=' + id + ']', function(event) {
+                    .on('click', '[i-id="' + id + '"]', function(event) {
                         var $this = $(this);
                         if (!$this.attr('disabled')) { // IE BUG
                             that._trigger(id);


### PR DESCRIPTION
修改代码 src/dialog.js 的 393 行，
选择器[key=value]的形式下，会出现的问题如下：
当button的配置项内没有 id， 并且 value 的值时多个英文单词，例如：Click me. 这个情况下，该按钮的i-id=Click me。 因此造成 [i-id=Click me]这个选择无法获取按钮的dom，导致功能异常。

修改成[key="value"]的形式，则可解决该问题。