### PR TITLE
fix https://github.com/aui/artDialog/issues/344

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "art-dialog",
-    "version": "7.0.0",
+    "version": "7.0.01",
     "readmeFilename": "README.md",
     "description": "A smart dialog box component",
     "homepage": "https://github.com/aui/artDialog",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,14 @@
 var webpack = require('webpack');
 var version = require('./package.json').version;
+const path = require('path')
 
 module.exports = {
     entry: {
         'dialog': './src/dialog.js',
-        'dialog-plus': './src/dialog-plus.js'
+        'dialog-plus':'./src/dialog-plus.js'
     },
     output: {
-        path: 'dist',
+        path:path.resolve(__dirname, './dist'),
         filename: '[name].js',
         library: `dialog`,
         libraryTarget: 'umd'


### PR DESCRIPTION
Webpack 'configuration.output.path: The provided value "dist" is not an absolute path!'
updated version 7.0.1